### PR TITLE
added metrics for replication lag

### DIFF
--- a/types.db
+++ b/types.db
@@ -1,6 +1,6 @@
 cache_ratio                     value:GAUGE:0:100
 connections                     value:GAUGE:0:U
-counter                         value:COUNTER:U:U
+counter                         value:GAUGE:0:U
 file_size                       bytes:GAUGE:0:U
 bytes                           value:COUNTER:0:U
 memory                          value:GAUGE:0:281474976710656


### PR DESCRIPTION
Max replication lag metric seen from a primary node. 
Deleted types.db, the file exists here 
https://github.com/signalfuse/docker-third-party-testing/blob/master/apps/mongodb-2.6/types.db
https://github.com/signalfuse/docker-third-party-testing/blob/master/apps/mongodb-3.0/types.db
