### PR TITLE
Use LooseVersion instead of StrictVersion for version checking

### DIFF
--- a/mongodb.py
+++ b/mongodb.py
@@ -5,7 +5,7 @@
 import collectd
 import collections
 import pymongo
-from distutils.version import StrictVersion as V
+from distutils.version import LooseVersion as V
 
 
 class MongoDB(object):


### PR DESCRIPTION
LooseVersion allows for nearly any version to be passed through as a string. We have users running version of mongodb like `3.1.0-1.1.0` which are not being handled by StrictVersion, and cause the plugin to crash. See https://www.python.org/dev/peps/pep-0386/ for details on differences of LooseVersion vs StrictVersion.