### PR TITLE
Fix PR# 31

### DIFF
--- a/mongodb.py
+++ b/mongodb.py
@@ -184,7 +184,7 @@ class MongoDB(object):
         if 'mem' in server_status:
             for t in ['resident', 'virtual', 'mapped']:
                 mem_metric = server_status['mem'].get(t)
-                if mem_metric:
+                if mem_metric is not None:
                     self.submit('gauge', 'mem.' + t, mem_metric)
 
         # network


### PR DESCRIPTION
fix https://github.com/signalfx/collectd-mongodb/pull/31

Address this exception when MMAPv1 is not in use

```
time="2020-03-27T08:09:59Z" level=error msg="Traceback (most recent call last):\n\n  File \"/usr/lib/signalfx-agent/lib/python3.8/site-packages/sfxrunner/scheduler/simple.py\", line 50, in _call_on_interval\n    func()\n\n  File \"/usr/lib/signalfx-agent/collectd-python/mongodb/mongodb.py\", line 186, in do_server_status\n    self.submit('gauge', 'mem.' + t, server_status['mem'][t])\n\nKeyError: 'mapped'\n" createdTime=1.5852965995932808e+09 lineno=56 logger=root monitorID=3 monitorType=collectd/mongodb runnerPID=8134 sourcePath=/usr/lib/signalfx-agent/lib/python3.8/site-packages/sfxrunner/logs.py
```