### PR TITLE
heap size for version 3.3 and above

### DIFF
--- a/mongodb.py
+++ b/mongodb.py
@@ -223,6 +223,13 @@ class MongoDB(object):
                             server_status['extra_info'][
                                 'heap_usage_bytes'])
 
+        # version 3.3 and above, extra_info.heap_usage_bytes is no longer available
+        if 'tcmalloc' in server_status and 'generic' in server_status['tcmalloc'] and 'heap_size' in \
+                server_status['tcmalloc']['generic']:
+            self.submit('gauge', 'tcmalloc.generic.heap_size',
+                        server_status['tcmalloc'][
+                            'generic']['heap_size'])
+
         lock_type = {'R': 'read', 'W': 'write', 'r': 'intentShared',
                      'w': 'intentExclusive'}
         lock_metric_type = {'deadlockCount': 'counter',


### PR DESCRIPTION
Starting mongo v3.3 https://github.com/mongodb/mongo/commit/bba9c97803dd5bcab8f8634565154aae5e3eda35 `extra_info.heap_usage_bytes` is no longer available the recommendation is to use `tcmalloc.generic.heap_size` instead
```
tcmalloc" : {
		"generic" : {
			"current_allocated_bytes" : 71016616,
			"heap_size" : 75436032
```

I had 2 options: 
1- use the value of `tcmalloc.generic.heap_size`  and stick it to `extra_info.heap_usage_bytes` 
or 
2- use the current metric naming convention and introduce a new metric `tcmalloc.generic.heap_size`

I chose number 2 , if an older server had both (which I doubt) then we'll send both, otherwise, we send the new metric `tcmalloc.generic.heap_size`

cc: @keitwb @mstumpfx 

Signed-off-by: Dani Louca <dlouca@splunk.com>