### PR TITLE
numExtents has been deprecated in 4.x

### DIFF
--- a/mongodb.py
+++ b/mongodb.py
@@ -314,8 +314,9 @@ class MongoDB(object):
                         db_stats['objects'], mongo_db)
             self.submit('gauge', 'collections',
                         db_stats['collections'], mongo_db)
-            self.submit('gauge', 'numExtents',
-                        db_stats['numExtents'], mongo_db)
+            if 'numExtents' in db_stats:
+                self.submit('gauge', 'numExtents',
+                            db_stats['numExtents'], mongo_db)
             self.submit('gauge', 'indexes',
                         db_stats['indexes'], mongo_db)
 


### PR DESCRIPTION
numExtents key is causing this error
```
time="2020-12-15T10:32:10+01:00" level=error msg="Traceback (most recent call last):\n\n  File \"/usr/lib/signalfx-agent/lib/python3.8/site-packages/sfxrunner/scheduler/simple.py\", line 50, in _call_on_interval\n    func()\n\n  File \"/usr/lib/signalfx-agent/collectd-python/mongodb/mongodb.py\", line 311, in do_server_status\n    db_stats['numExtents'], mongo_db)\n\nKeyError: 'numExtents'\n" createdTime=1.6080247304047654e+09 lineno=56 logger=root monitorID=10   monitorType=collectd/mongodb runnerPID=29576 sourcePath=/usr/lib/signalfx-agent/lib/python3.8/site-packages/sfxrunner/logs.py
```

this is due to this change, where `numExtents` no longer exists
https://github.com/mongodb/mongo/commit/47ee8f8cde1d1e116caf223458c15b4af10943d6

Signed-off-by: Dani Louca <dlouca@splunk.com>