### PR TITLE
check for unexpected values due to changed json output

### DIFF
--- a/mongodb.py
+++ b/mongodb.py
@@ -34,6 +34,10 @@ class MongoDB(object):
         self.ssl_client_key_passphrase = None
 
     def submit(self, type, type_instance, value, db=None, extra_dims=None):
+        if isinstance(value, list) or isinstance(value, dict):
+            self.log('ERROR: unsupported value type for metric %s with value %s' % (type_instance, value))
+            return
+
         v = collectd.Values()
         v.plugin = self.plugin_name
 
@@ -178,7 +182,8 @@ class MongoDB(object):
         # operations
         if 'opcounters' in server_status:
             for k, v in list(server_status['opcounters'].items()):
-                self.submit('counter', 'opcounters.' + k, v)
+                if k != "deprecated":
+                    self.submit('counter', 'opcounters.' + k, v)
 
         # memory
         if 'mem' in server_status:


### PR DESCRIPTION
`serverStatus` is returning this output 

```
        "opcounters" : {
                "insert" : NumberLong(1105),
                "query" : NumberLong(212776),
                "update" : NumberLong(228522),
                "delete" : NumberLong(105),
                "getmore" : NumberLong(14),
                "command" : NumberLong(11096372),
                "deprecated" : {
                        "total" : NumberLong(22),
                        "insert" : NumberLong(0),
                        "query" : NumberLong(22),
                        "update" : NumberLong(0),
                        "delete" : NumberLong(0),
                        "getmore" : NumberLong(0),
                        "killcursors" : NumberLong(0)
                }
        }
```
which is resulting of this error

```
python/python.go:164        Could not handle message from Python        {"kind": "receiver", "name": "smartagent/mongodb", "error": "parse error: expected number near offset 29 of 'values'"
```

The changes skips the known bad element `deprecated` and further checks to make sure we don't submit a list or dict

Signed-off-by: Dani Louca <dlouca@splunk.com>